### PR TITLE
fix: beta token log darajasini DEBUG ga o'zgartirish

### DIFF
--- a/src/aiso_core/services/beta_access_service.py
+++ b/src/aiso_core/services/beta_access_service.py
@@ -138,7 +138,7 @@ class BetaAccessService:
 
         if not settings.smtp_host:
             # NOTE(beta): SMTP bo'lmasa local/test rejimda link logga chiqariladi.
-            logger.warning(
+            logger.debug(
                 "SMTP is not configured; beta link was not emailed. recipient=%s link=%s",
                 recipient_email,
                 register_link,


### PR DESCRIPTION
## O'zgarish

Beta access service'da SMTP sozlanmagan holatda beta token linkini logga chiqarish darajasi `WARNING` dan `DEBUG` ga o'zgartirildi.

### Sabab
SMTP sozlanmagan local/test muhitda bu xabar `WARNING` darajasida chiqishi kerak emas — bu kutilgan holat va debug ma'lumot sifatida yetarli.

### O'zgartirilgan fayl
- `src/aiso_core/services/beta_access_service.py` — `logger.warning` → `logger.debug`