### PR TITLE
fix: container ichida .bashrc va .profile ko'rinmasligi muammosini tuzatish

### DIFF
--- a/docker/user-base/profile.default
+++ b/docker/user-base/profile.default
@@ -1,0 +1,7 @@
+# ~/.profile — login shell uchun bashrc yuklash
+
+if [ -n "$BASH_VERSION" ]; then
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi

--- a/src/aiso_core/services/container_service.py
+++ b/src/aiso_core/services/container_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import shutil
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -38,12 +39,34 @@ def _get_user_data_path(user_id: uuid.UUID) -> str:
     return os.path.abspath(os.path.join(settings.user_data_base_path, str(user_id)))
 
 
+_DOTFILES_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "docker", "user-base")
+)
+
+
+def _copy_default_dotfiles(home_dir: str) -> None:
+    """Default dotfile larni home papkaga nusxalaydi (faqat mavjud bo'lmasa)."""
+    dotfiles = {
+        "bashrc.default": ".bashrc",
+        "profile.default": ".profile",
+    }
+    for src_name, dest_name in dotfiles.items():
+        src = os.path.join(_DOTFILES_DIR, src_name)
+        dest = os.path.join(home_dir, dest_name)
+        if not os.path.exists(dest) and os.path.exists(src):
+            shutil.copy2(src, dest)
+
+
 def _create_user_dirs(user_id: uuid.UUID) -> str:
     """Foydalanuvchi direktoriyalarini yaratadi."""
     base = _get_user_data_path(user_id)
     subdirs = ["Desktop", "Documents", "Downloads", "Pictures", "Music", "Videos", ".Trash"]
     for subdir in subdirs:
         os.makedirs(os.path.join(base, subdir), exist_ok=True)
+
+    # Default dotfile larni nusxalash (faqat mavjud bo'lmasa)
+    _copy_default_dotfiles(base)
+
     return base
 
 


### PR DESCRIPTION
## Muammo

Container yaratilganda host papkasi (`/data/users/{user_id}`) `/home/aisu` ga volume mount qilinadi. Bu mount Docker image ichidagi barcha fayllarni — jumladan `.bashrc` ni ham — to'liq qoplaydi. Natijada foydalanuvchi terminalga kirganda `.bashrc` yo'q bo'ladi.

## Yechim

- `_create_user_dirs()` funksiyasiga `_copy_default_dotfiles()` chaqiruvi qo'shildi
- `docker/user-base/bashrc.default` va yangi `profile.default` fayllarini host papkaga nusxalaydi
- Faqat fayl **mavjud bo'lmasa** nusxalanadi — foydalanuvchi o'zgartirgan `.bashrc` ustiga yozilmaydi

## O'zgartirilgan fayllar

- `src/aiso_core/services/container_service.py` — `_copy_default_dotfiles()` funksiya va `shutil` import qo'shildi
- `docker/user-base/profile.default` — yangi fayl (login shell da `.bashrc` ni yuklaydi)

## Testlar

Barcha 140 ta test muvaffaqiyatli o'tdi.